### PR TITLE
[API] send w/ CSRF token

### DIFF
--- a/src/app/home/Home.tsx
+++ b/src/app/home/Home.tsx
@@ -2,19 +2,22 @@ import React from 'react';
 import './Home.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import useCsrfToken from 'app/hooks/useCsrfToken';
 
 export default function Home() {
+  const [csrfToken] = useCsrfToken();
   return (
     <div className="container mt-5">
       <h2>欢迎来到【玩儿技术】社区</h2>
       <h2>在这里找到志同道合的技术热爱者一起享受创造的乐趣！社区网站正在从零开始搭建当中。我们需要你的协助</h2>
       <br />
       <form action="https://api.tech-gamers.live/auth/github" method="post">
-        <button type="submit" className="ant-btn ant-btn-lg ant-btn-block">
+        <input type="hidden" name="authenticity_token" value={csrfToken} />
+        <button type="submit" className="ant-btn ant-btn-lg ant-btn-block" disabled={csrfToken.length === 0}>
           Sign in with Github &nbsp;
           <FontAwesomeIcon icon={faGithub} />
         </button>
       </form>
-    </div >
+    </div>
   );
 }

--- a/src/app/hooks/useCsrfToken.ts
+++ b/src/app/hooks/useCsrfToken.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+import { api } from 'app/utils';
+
+export default (): [string, (v: string) => void] => {
+  const [csrfToken, setCsrfToken] = useState('');
+
+  useEffect(() => {
+    api.handshake().then(setCsrfToken);
+  }, []);
+
+  return [csrfToken, setCsrfToken];
+};

--- a/src/app/user/User.tsx
+++ b/src/app/user/User.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useCallback } from 'react';
 import './User.scss';
 import { Avatar, Descriptions, Button } from 'antd';
 import { UserOutlined } from '@ant-design/icons';
@@ -8,17 +8,11 @@ import { UserContext } from 'app/contexts/user.context';
 export default function User(props: any) {
   const { user, setUser } = useContext(UserContext);
 
-  /**
-   * Sign out current user
-   */
-  const onSignOut = () => {
+  const onSignOut = useCallback(() => {
     // TODO: sign out only already signed in
     api.delete('user/session').finally(() => props.history.push('/'));
-  }
+  }, [props.history]);
 
-  /**
-   * @override
-   */
   useEffect(() => {
     const { userId } = props.match.params;
     api
@@ -29,18 +23,12 @@ export default function User(props: any) {
           onSignOut();
         }
       });
-  })
+  }, [onSignOut, props.match.params, setUser]);
 
   return (
     <div className="container mt-5">
       <div className="text-center">
-        {
-          user.avatar_url ? (
-            <Avatar size={120} src={user.avatar_url} />
-          ) : (
-            <Avatar size={120} icon={<UserOutlined />} />
-          )
-        }
+        {user.avatar_url ? <Avatar size={120} src={user.avatar_url} /> : <Avatar size={120} icon={<UserOutlined />} />}
       </div>
       <Descriptions title="User Info">
         <Descriptions.Item label="User Name">{user.name}</Descriptions.Item>

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -2,17 +2,58 @@ import axios from 'axios';
 
 const BASE_URL = 'https://api.tech-gamers.live/';
 
-export const api = {
-  get(url: string) {
-    return axios.get(`${BASE_URL}${url}`);
+type RESTMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+type API = {
+  [key in RESTMethod]: (url: string) => Promise<any>;
+} & {
+  request: (method: RESTMethod, url: string) => Promise<any>;
+};
+
+type CSRFTracker = {
+  csrfToken: string;
+  handshake: () => Promise<string>;
+};
+
+export const api: API & CSRFTracker = {
+  async get(url: string) {
+    return await this.request('get', url);
   },
-  post(url: string) {
-    return axios.post(`${BASE_URL}${url}`);
+  async post(url: string) {
+    return await this.request('post', url);
   },
-  put(url: string) {
-    return axios.put(`${BASE_URL}${url}`);
+  async put(url: string) {
+    return await this.request('put', url);
   },
-  delete(url: string) {
-    return axios.delete(`${BASE_URL}${url}`);
+  async patch(url: string) {
+    return await this.request('patch', url);
+  },
+  async delete(url: string) {
+    return await this.request('delete', url);
+  },
+
+  csrfToken: '',
+  async handshake() {
+    const res = await this.request('post', 'auth/handshake');
+    this.csrfToken = res.headers['x-csrf-token'];
+    return this.csrfToken;
+  },
+
+  async request(method: RESTMethod, url: string) {
+    try {
+      const res = await axios.request({
+        method: method,
+        url: `${BASE_URL}/${url}`,
+        headers: {
+          'X-CSRF-Token': this.csrfToken
+        }
+      });
+      this.csrfToken = res.headers['x-csrf-token'];
+      return res;
+    } catch (err) {
+      // TODO: a global error handler
+      // TODO: auto handshake and retry on 422
+      window.console.error(err);
+    }
   }
 };

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -39,21 +39,21 @@ export const api: API & CSRFTracker = {
     return this.csrfToken;
   },
 
+  // TODO: a global error handler
+  // TODO: auto handshake and retry on 422
   async request(method: RESTMethod, url: string) {
-    try {
-      const res = await axios.request({
-        method: method,
-        url: `${BASE_URL}/${url}`,
-        headers: {
-          'X-CSRF-Token': this.csrfToken
-        }
-      });
-      this.csrfToken = res.headers['x-csrf-token'];
-      return res;
-    } catch (err) {
-      // TODO: a global error handler
-      // TODO: auto handshake and retry on 422
-      window.console.error(err);
-    }
+    const res = await axios.request({
+      method: method,
+      baseURL: BASE_URL,
+      url: url,
+      xsrfCookieName: '_SPI_session',
+      xsrfHeaderName: 'X-CSRF-Token',
+      headers: {
+        'X-CSRF-Token': this.csrfToken
+      },
+      withCredentials: true
+    });
+    this.csrfToken = res.headers['x-csrf-token'];
+    return res;
   }
 };


### PR DESCRIPTION
- [x] fix the CORS for the local testing frontend

> The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.

- [x] frontend failed to set cookie atm

now it can be set on `alpha.tech-gamers.live`

- [x] still got 422