### PR TITLE
[INFRA] Enable local development with environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ dist
 # testing
 /coverage
 
+# env
+.env
+
 # production
 /build
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/react-dom": "^16.9.0",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
+    "dotenv": "^8.2.0",
     "eslint": "^6.6.0",
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -61,7 +61,7 @@ export const api: API & CSRFTracker = {
       if (REACT_APP_TOKEN) {
         requestConfig.headers['Authorization'] = `Bearer ${REACT_APP_TOKEN}`;
       } else {
-        console.error('REACT_APP_TOKEN not found in .env file');
+        throw 'REACT_APP_TOKEN not found in .env file';
       }
     }
 

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosResponse, AxiosRequestConfig } from 'axios';
 
 const BASE_URL = 'https://api.tech-gamers.live/';
 
@@ -43,7 +43,7 @@ export const api: API & CSRFTracker = {
   // TODO: a global error handler
   // TODO: auto handshake and retry on 422
   async request<T>(method: RESTMethod, url: string): Promise<AxiosResponse<T>> {
-    const res = await axios.request<T>({
+    const requestConfig: AxiosRequestConfig = {
       method: method,
       baseURL: BASE_URL,
       url: url,
@@ -53,7 +53,14 @@ export const api: API & CSRFTracker = {
         'X-CSRF-Token': this.csrfToken
       },
       withCredentials: true
-    });
+    };
+
+    // Add bearer token when is in dev mode
+    if (process.env.NODE_ENV === 'development') {
+      requestConfig.headers['Authorization'] = `Bearer ${process.env.REACT_APP_TOKEN}`;
+    }
+
+    const res = await axios.request<T>(requestConfig);
     this.csrfToken = res.headers['x-csrf-token'];
     return res;
   }

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -56,8 +56,13 @@ export const api: API & CSRFTracker = {
     };
 
     // Add bearer token when is in dev mode
-    if (process.env.NODE_ENV === 'development') {
-      requestConfig.headers['Authorization'] = `Bearer ${process.env.REACT_APP_TOKEN}`;
+    const { NODE_ENV, REACT_APP_TOKEN } = process.env;
+    if (NODE_ENV === 'development') {
+      if (REACT_APP_TOKEN) {
+        requestConfig.headers['Authorization'] = `Bearer ${REACT_APP_TOKEN}`;
+      } else {
+        console.error('REACT_APP_TOKEN not found in .env file');
+      }
     }
 
     const res = await axios.request<T>(requestConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,7 +4294,7 @@ dotenv-expand@5.1.0:
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
-dotenv@8.2.0:
+dotenv@8.2.0, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==


### PR DESCRIPTION
Use `.env` to store the token, which won't check-in to the source code.

In api util, when environment is development, add Authorization into request header. 